### PR TITLE
Update plugin name and stable version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+1.0.4 (2025-06-23)
+* Update plugin name and stable version.
+
 1.0.3 (2025-06-19)
 * Name change.
 

--- a/dm1881.php
+++ b/dm1881.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * Plugin Name:          GIT 1881 Number Lookup
+ * Plugin Name:          1881 Number Lookup
  * Description:          Adds lookup of adress and contact information from 1881 in WooCommerce checkout.
  * Author:               Digitale Medier 1881
  * Author URI:           https://www.1881.no
- * Version:              1.0.3
+ * Version:              1.0.4
  * Text Domain:          1881-number-lookup
  * Domain Path:          /languages
  * Requires Plugins:     woocommerce

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === 1881 Number Lookup ===
 Contributors: dekode
 Requires at least: 6.0
-Tested up to: 6.8.1
+Tested up to: 6.8
 Stable tag: 1.0.4
 Requires PHP: 7.4
 License: GPLv3 or later


### PR DESCRIPTION
This pull request includes updates to the plugin's metadata, versioning, and documentation to reflect the release of version 1.0.4. The changes ensure consistency across files and update the tested WordPress version.

### Versioning and metadata updates:
* Updated the plugin version from `1.0.3` to `1.0.4` in `dm1881.php` to reflect the new release.
* Changed the plugin name from "GIT 1881 Number Lookup" to "1881 Number Lookup" in `dm1881.php` for consistency.

### Documentation updates:
* Added a new entry for version `1.0.4` in `CHANGELOG.md` with details about the updated plugin name and stable version.
* Updated the `readme.txt` file to set the "Tested up to" field from `6.8.1` to `6.8`, ensuring compatibility information is current.