### PR TITLE
Update plugin name / Fix WPCS / Add hash to phone number transient key

### DIFF
--- a/1881-number-lookup.php
+++ b/1881-number-lookup.php
@@ -25,7 +25,7 @@ namespace DM1881;
 \define( 'DM1881_PATH', __DIR__ );
 \define( 'DM1881_URL', \plugins_url( '', __FILE__ ) );
 
-\add_action( 'plugins_loaded', function() {
+\add_action( 'plugins_loaded', function () {
 	/***
 	 * Check if WooCommerce is active before running code.
 	 */

--- a/includes/core.php
+++ b/includes/core.php
@@ -60,7 +60,7 @@ function rest_perform_search( \WP_REST_Request $request = null ) {
 		], 200 );
 	}
 
-	$transient_key = 'dm1881_phonelookup_' . $phone;
+	$transient_key = 'dm1881_phonelookup_' . \wp_hash( $phone );
 
 	$search_results = \get_transient( $transient_key );
 	if ( false === $search_results ) {


### PR DESCRIPTION
This pull request includes a security improvement to the `rest_perform_search` function in `includes/core.php`. The change ensures that transient keys are hashed to prevent potential security vulnerabilities.

* Security enhancement:
  * [`includes/core.php`](diffhunk://#diff-21e944aca0f42ff6529bde979b0fd787d00e010406e6642f947e71bf5e6f5ad1L63-R63): Updated the `$transient_key` to use `\wp_hash()` for hashing the `$phone` variable, improving security by avoiding direct use of potentially sensitive data in the transient key.